### PR TITLE
Fix link for help find command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -32,7 +32,7 @@ public class HelpCommand extends Command {
             Map.entry("list", "#listing-all-persons--list"),
             Map.entry("sort", "#sorting-persons--sort"),
             Map.entry("edit", "#editing-a-person--edit"),
-            Map.entry("find", "#locating-persons-by-nameemail--find"),
+            Map.entry("find", "#locating-persons-by-nameemailtag--find"),
             Map.entry("delete", "#deleting-a-person--delete"),
             Map.entry("clear", "#clearing-all-entries--clear"),
             Map.entry("exit", "#exiting-the-program--exit"),


### PR DESCRIPTION
Fix #277 

**Summary:**
- Running `help find` should now correctly open that section in the correct section in the user guide.