### PR TITLE
Update NUS email domain

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -746,7 +746,7 @@ Use case ends.
 * GUI (Graphical user interface): A visual way for users to interact with digital components through items like icons and buttons.
 * Index: A positive integer representing the position of a contact in the currently displayed list.
 * Mainstream OS: Windows, Linux, Unix, MacOS.
-* NUS domain: Email addresses ending with `@u.nus.edu` (student), `@nus.edu.sg` (staff), or `@*.nus.edu.sg`.
+* NUS domain: Email addresses from NUS-affiliated domains, including `@u.nus.edu, @*.nus.edu, @nus.edu.sg, @*.nus.edu.sg, @duke-nus.edu.sg, @*.duke-nus.edu.sg, @yale-nus.edu.sg, and @*.yale-nus.edu.sg`.
 * Prefix: A short identifier (e.g. `n/`, `e/`, `tg/`) used in commands to denote the type of parameter that follows.
 * Professor: An academic staff member who teaches a course at NUS.
 * Role tag: A type of tag (displayed in green) used to label a contact's academic role. Its prefix is `tr/`.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -102,12 +102,17 @@ Emails should be of the format `local-part@domain` and adhere to the following c
 
 CampusBridge is designed for NUS students and staff. When adding or editing a contact:
 
-| Email domain            | Behavior                                   |
-|-------------------------|--------------------------------------------|
-| `@u.nus.edu` (student)  | No warning                                 |
-| `@nus.edu.sg` (staff)   | No warning                                 |
-| `@*.nus.edu.sg` (staff) | No warning                                 |
-| Other domains           | Warning shown (but contact is still added) |
+| Email domain         | Behavior                                   |
+|----------------------|--------------------------------------------|
+| `@u.nus.edu`         | No warning                                 |
+| `@*.nus.edu`         | No warning                                 |
+| `@nus.edu.sg`        | No warning                                 |
+| `@*.nus.edu.sg`      | No warning                                 |
+| `@duke-nus.edu.sg`   | No warning                                 |
+| `@*.duke-nus.edu.sg` | No warning                                 |
+| `@yale-nus.edu.sg`   | No warning                                 |
+| `@*.yale-nus.edu.sg` | No warning                                 |
+| Other domains        | Warning shown (but contact is still added) |
 
 <div markdown="span" class="alert alert-warning">:exclamation: **Note:**
 Non-NUS emails are still accepted, but a warning will be displayed to alert you that the email does not belong to an NUS domain.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -222,7 +222,7 @@ Edits an existing person in the address book.
   Other special characters are not supported. In particular, `/` is not accepted because it may be interpreted as command syntax. If needed, replace it with a supported symbol instead, e.g. `D/O` as `D-O`.
 
 <div markdown="span" class="alert alert-info">:information_source: **Note:**
-If the updated email is not an [NUS domain](#email-validation) (`@u.nus.edu` or `@*.nus.edu.sg` or `@nus.edu.sg`), a warning message will be shown. The contact will still be updated.
+If the updated email is not an [NUS domain](#email-validation), a warning message will be shown. The contact will still be updated.
 </div>
 
 **Examples:**

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -32,9 +32,13 @@ public class Email {
     private static final String DOMAIN_LAST_PART_REGEX = "(" + DOMAIN_PART_REGEX + "){2,}$"; // At least two chars
     private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)*" + DOMAIN_LAST_PART_REGEX;
     public static final String VALIDATION_REGEX = LOCAL_PART_REGEX + "@" + DOMAIN_REGEX;
+    private static final String DUKE_NUS_STUDENT_DOMAIN = "@u.duke.nus.edu";
+    private static final String DUKE_NUS_STAFF_DOMAIN = "@duke-nus.edu.sg";
     private static final String NUS_PERIOD_STAFF_DOMAIN = "@nus.edu.sg";
     private static final String NUS_STUDENT_DOMAIN = "@u.nus.edu";
     private static final String NUS_STAFF_DOMAIN = ".nus.edu.sg";
+    private static final String YALE_NUS_STUDENT_DOMAIN = "@u.yale-nus.edu.sg";
+    private static final String YALE_NUS_STAFF_DOMAIN = "@yale-nus.edu.sg";
     public final String value;
 
     /**
@@ -95,7 +99,8 @@ public class Email {
 
     public boolean isNusDomain() {
         return value.endsWith(NUS_STUDENT_DOMAIN) || value.endsWith(NUS_STAFF_DOMAIN)
-                || value.endsWith(NUS_PERIOD_STAFF_DOMAIN);
+                || value.endsWith(NUS_PERIOD_STAFF_DOMAIN)
+                || value.endsWith(DUKE_NUS_STUDENT_DOMAIN) || value.endsWith(DUKE_NUS_STAFF_DOMAIN)
+                || value.endsWith(YALE_NUS_STUDENT_DOMAIN) || value.endsWith(YALE_NUS_STAFF_DOMAIN);
     }
-
 }

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -34,9 +34,9 @@ public class Email {
     private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)*" + DOMAIN_LAST_PART_REGEX;
     public static final String VALIDATION_REGEX = LOCAL_PART_REGEX + "@" + DOMAIN_REGEX;
     private static final String[] NUS_DOMAINS = {
-            ".nus.edu", ".nus.edu.sg", "@nus.edu.sg",
-            ".duke-nus.edu.sg", "@duke-nus.edu.sg",
-            ".yale-nus.edu.sg", "@yale-nus.edu.sg"
+        ".nus.edu", ".nus.edu.sg", "@nus.edu.sg",
+        ".duke-nus.edu.sg", "@duke-nus.edu.sg",
+        ".yale-nus.edu.sg", "@yale-nus.edu.sg"
     };
     public final String value;
 

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -3,6 +3,7 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import java.util.Arrays;
 import java.util.Locale;
 
 /**
@@ -32,13 +33,11 @@ public class Email {
     private static final String DOMAIN_LAST_PART_REGEX = "(" + DOMAIN_PART_REGEX + "){2,}$"; // At least two chars
     private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)*" + DOMAIN_LAST_PART_REGEX;
     public static final String VALIDATION_REGEX = LOCAL_PART_REGEX + "@" + DOMAIN_REGEX;
-    private static final String DUKE_NUS_STUDENT_DOMAIN = "@u.duke.nus.edu";
-    private static final String DUKE_NUS_STAFF_DOMAIN = "@duke-nus.edu.sg";
-    private static final String NUS_PERIOD_STAFF_DOMAIN = "@nus.edu.sg";
-    private static final String NUS_STUDENT_DOMAIN = "@u.nus.edu";
-    private static final String NUS_STAFF_DOMAIN = ".nus.edu.sg";
-    private static final String YALE_NUS_STUDENT_DOMAIN = "@u.yale-nus.edu.sg";
-    private static final String YALE_NUS_STAFF_DOMAIN = "@yale-nus.edu.sg";
+    private static final String[] NUS_DOMAINS = {
+            ".nus.edu", ".nus.edu.sg", "@nus.edu.sg",
+            ".duke-nus.edu.sg", "@duke-nus.edu.sg",
+            ".yale-nus.edu.sg", "@yale-nus.edu.sg"
+    };
     public final String value;
 
     /**
@@ -98,9 +97,6 @@ public class Email {
     }
 
     public boolean isNusDomain() {
-        return value.endsWith(NUS_STUDENT_DOMAIN) || value.endsWith(NUS_STAFF_DOMAIN)
-                || value.endsWith(NUS_PERIOD_STAFF_DOMAIN)
-                || value.endsWith(DUKE_NUS_STUDENT_DOMAIN) || value.endsWith(DUKE_NUS_STAFF_DOMAIN)
-                || value.endsWith(YALE_NUS_STUDENT_DOMAIN) || value.endsWith(YALE_NUS_STAFF_DOMAIN);
+        return Arrays.stream(NUS_DOMAINS).anyMatch(value::endsWith);
     }
 }

--- a/src/test/java/seedu/address/model/person/EmailTest.java
+++ b/src/test/java/seedu/address/model/person/EmailTest.java
@@ -155,4 +155,16 @@ public class EmailTest {
         assertFalse(new Email("scam@fakenus.edu.sg").isNusDomain());
         assertFalse(new Email("fake@notnus.edu.sg").isNusDomain());
     }
+
+    @Test
+    public void isNusDomain_dukeNusEmail_returnsTrue() {
+        assertTrue(new Email("student@u.duke.nus.edu").isNusDomain());
+        assertTrue(new Email("prof@duke-nus.edu.sg").isNusDomain());
+    }
+
+    @Test
+    public void isNusDomain_yaleNusEmail_returnsTrue() {
+        assertTrue(new Email("student@u.yale-nus.edu.sg").isNusDomain());
+        assertTrue(new Email("prof@yale-nus.edu.sg").isNusDomain());
+    }
 }

--- a/src/test/java/seedu/address/model/person/EmailTest.java
+++ b/src/test/java/seedu/address/model/person/EmailTest.java
@@ -160,6 +160,7 @@ public class EmailTest {
     public void isNusDomain_dukeNusEmail_returnsTrue() {
         assertTrue(new Email("student@u.duke.nus.edu").isNusDomain());
         assertTrue(new Email("prof@duke-nus.edu.sg").isNusDomain());
+        assertTrue(new Email("user@se.duke-nus.edu.sg").isNusDomain());
     }
 
     @Test


### PR DESCRIPTION
Valid NUS emails


| Email domain              | Behavior                                   |
|---------------------------|--------------------------------------------|
| `@*.nus.edu`              | No warning                                 |
| `@nus.edu.sg`             | No warning                                 |
| `@*.nus.edu.sg`           | No warning                                 |
| `@duke-nus.edu.sg`        | No warning                                 |
| `@*.duke-nus.edu.sg`      | No warning                                 |
| `@yale-nus.edu.sg`        | No warning                                 |
| `@*.yale-nus.edu.sg`      | No warning                                 |
| Other domains             | Warning shown (but contact is still added) |


After serious consideration, I have decided to make the above emails valid. To justify against false positives during PE, we can mention that NUS controls these domains, and not anyone can just make an invalid email outside of CampusBridge. (e.g hi@notlegit.nus.edu.sg). Further, NUS can change domains whenever they want, and it is better to make our app more flexible.

We can still consider putting this in the planned enhancements in case there are any false negatives I missed out on.

closes #498 
closes #500 

taken from these 2 websites

https://nusit.nus.edu.sg/services/collaboration-and-productivity/nusmail/studentemail/

https://nusit.nus.edu.sg/uncategorized/nus-anti-phishing-disclaimer-page/