### PR TITLE
Case insensitive command

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -814,8 +814,11 @@ testers are expected to do more *exploratory* testing.
     1. Test case: `help add`<br>
        Expected: The User Guide opens in the system default browser at the `add` command section. Status message shows `Opening user guide for 'add' command.`
 
-    1. Other valid command names to try: `help list`, `help edit`, `help delete`, `help find`, `help sort`, `help tag`, `help untag`, `help cleartag`, `help clear`, `help exit`<br>
-       Expected: The User Guide opens at the respective command section. Status message names the command.
+   1. Test case: `help ADD`<br>
+      Expected: The User Guide opens in the system default browser at the `add` command section. Status message shows `Opening user guide for 'add' command.`
+
+   1. Other valid command names to try: `help list`, `help edit`, `help delete`, `help find`, `help sort`, `help tag`, `help untag`, `help cleartag`, `help clear`, `help exit`<br>
+      Expected: The User Guide opens at the respective command section. Status message names the command.
 
 1. Opening help without internet connection
 
@@ -831,10 +834,7 @@ testers are expected to do more *exploratory* testing.
 
     1. Test case: `help INVALID`<br>
        Expected: The User Guide does not open. Error details shown in the status message.
-
-    1. Test case: `help ADD` (uppercase)<br>
-       Expected: Same as above. Command names are case-sensitive and must be lowercase.
-
+   
     1. Test case: `help add extra`<br>
        Expected: Same as above. Only a single command name is accepted; extra words cause a format error.
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -137,6 +137,8 @@ Non-NUS emails are still accepted, but a warning will be displayed to alert you 
 * Prefixes are case-insensitive.<br>
   e.g. n/NAME and N/NAME are treated the same way.
 
+* Commands are case-insensitive. e.g. ADD, Add, and add are treated the same way.
+
 * If you are using a PDF version of this document, be careful when copying and pasting commands that span multiple lines as space characters surrounding line-breaks may be omitted when copied over to the application.
 </div>
 
@@ -149,6 +151,7 @@ Opens the user guide in the browser, and optionally directly to the section for 
 Alternatively, press `F1` or `fn + F1` to open the user guide.
 
 * `COMMAND` is optional. When provided, it must be a single valid command name (e.g. `add`, `edit`).
+* `COMMAND` is case-insensitive. e.g. `help ADD`, `help Add`, and `help add` are treated the same.
 * If `COMMAND` is provided, the user guide is opened at the section for that command.
 * If `COMMAND` is not a recognised command name, an error is shown listing all valid commands.
 * If more than one word is provided (e.g. `help add clear`), an invalid command format error is shown.

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -48,7 +48,7 @@ public class AddressBookParser {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
         }
 
-        final String commandWord = matcher.group("commandWord");
+        final String commandWord = matcher.group("commandWord").toLowerCase();
         final String arguments = matcher.group("arguments");
 
         // Note to developers: Change the log level in config.json to enable lower level (i.e., FINE, FINER and lower)

--- a/src/main/java/seedu/address/logic/parser/HelpCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/HelpCommandParser.java
@@ -17,7 +17,7 @@ public class HelpCommandParser implements Parser<HelpCommand> {
      * @throws ParseException if the user input does not conform to the expected format
      */
     public HelpCommand parse(String args) throws ParseException {
-        String trimmed = args.trim();
+        String trimmed = args.trim().toLowerCase();
         if (trimmed.isEmpty()) {
             return new HelpCommand();
         }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -185,4 +185,14 @@ public class AddressBookParserTest {
     public void parseCommand_unknownCommand_throwsParseException() {
         assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand"));
     }
+
+    @Test
+    public void parseCommand_caseInsensitive() throws Exception {
+        assertTrue(parser.parseCommand("ADD n/John e/john@example.com") instanceof AddCommand);
+        assertTrue(parser.parseCommand("HELP") instanceof HelpCommand);
+        assertTrue(parser.parseCommand("HELP add") instanceof HelpCommand);
+        assertTrue(parser.parseCommand("help ADD") instanceof HelpCommand);
+        assertTrue(parser.parseCommand("LIST") instanceof ListCommand);
+        assertTrue(parser.parseCommand("EXIT") instanceof ExitCommand);
+    }
 }

--- a/src/test/java/seedu/address/logic/parser/HelpCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/HelpCommandParserTest.java
@@ -48,7 +48,15 @@ public class HelpCommandParserTest {
     public void parse_invalidCommand_throwsParseException() {
         assertParseFailure(parser, "unknown",
                 String.format(HelpCommand.MESSAGE_UNKNOWN_COMMAND, "unknown"));
-        assertParseFailure(parser, "ADD",
-                String.format(HelpCommand.MESSAGE_UNKNOWN_COMMAND, "ADD"));
+        assertParseFailure(parser, "ADDD",
+                String.format(HelpCommand.MESSAGE_UNKNOWN_COMMAND, "addd"));
+    }
+
+
+    @Test
+    public void parse_validCommandUppercase_returnsHelpCommand() {
+        assertParseSuccess(parser, "ADD", new HelpCommand("add"));
+        assertParseSuccess(parser, "EDIT", new HelpCommand("edit"));
+        assertParseSuccess(parser, "List", new HelpCommand("list"));
     }
 }


### PR DESCRIPTION
closes #491 
closes #538

* Commands are case-insensitive. e.g. ADD, Add, and add are treated the same way. Same for the rest of the commands


* `COMMAND` is case-insensitive. e.g. `help ADD`, `help Add`, and `help add` are treated the same.
