### PR TITLE
Use substring only for find keyword with special characters

### DIFF
--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -65,8 +65,7 @@ public class FindCommandParser implements Parser<FindCommand> {
      * @return A list of valid keywords extracted from the specified prefix.
      * @throws ParseException if any keyword contains only special characters (no alphanumeric characters)
      */
-    private static List<String> parseKeywords(ArgumentMultimap argumentMultimap, Prefix prefix)
-            throws ParseException {
+    private static List<String> parseKeywords(ArgumentMultimap argumentMultimap, Prefix prefix) {
         List<String> validKeywords = new ArrayList<>();
 
         for (String value : argumentMultimap.getAllValues(prefix)) {
@@ -77,8 +76,6 @@ public class FindCommandParser implements Parser<FindCommand> {
                     continue;
                 }
 
-                // Check if token contains only special characters (no alphanumeric characters)
-                ParserUtil.validateKeywordContainsAlphanumeric(prefix, token);
                 validKeywords.add(token);
             }
         }

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -32,33 +32,40 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
     // Ratio of keyword length to determine allowed edits in fuzzy matching (e.g., 20% of the keyword length)
     private static final double EDIT_DISTANCE_RATIO = 0.2;
 
-    private final List<String> normalizedKeywords;
+    private final List<String> keywords;
 
     /**
      * Constructs a {@code NameContainsKeywordsPredicate} using a list of name keywords.
-     *
-     * <p> Keywords will be normalized to lowercase and any special characters are removed.</p>
      *
      * @param keywords The list of name keywords to match against (cannot be null or contain null elements)
      * @throws NullPointerException if {@code keywords} is null or contains null elements
      */
     public NameContainsKeywordsPredicate(List<String> keywords) {
         requireAllNonNull(keywords);
-
-        this.normalizedKeywords = keywords.stream()
-                .map(StringUtil::normalizeForFuzzyMatching)
-                .flatMap(s -> Arrays.stream(s.split("\\s+")))
-                .filter(s -> !s.isEmpty())
-                .toList();
+        this.keywords = keywords;
     }
 
     @Override
     public boolean test(Person person) {
+        boolean hasSpecialCharacters = keywords.stream()
+                .anyMatch(k -> k.matches(".*[^a-zA-Z0-9\\s].*"));
+
+        // Substring matching for keywords with special characters (e.g., "O'Connor", "Smith-Jones")
+        if (hasSpecialCharacters) {
+            String name = person.getName().fullName.toLowerCase();
+
+            return keywords.stream()
+                    .anyMatch(keyword -> name.contains(keyword.toLowerCase()));
+        }
+
         // Split name based on white spaces
         List<String> nameTokens = Arrays.asList(StringUtil.normalizeForFuzzyMatching(person.getName().fullName)
                         .split("\\s+"));
 
-        return normalizedKeywords.stream()
+        return keywords.stream()
+                .map(StringUtil::normalizeForFuzzyMatching) // normalise keywords
+                .flatMap(s -> Arrays.stream(s.split("\\s+")))
+                .filter(s -> !s.isEmpty()) // trim whitespace and remove empty tokens
                 .anyMatch(keyword -> keywordMatchesAnyToken(keyword, nameTokens));
     }
 
@@ -118,13 +125,13 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
             return false;
         }
 
-        return normalizedKeywords.equals(otherNameContainsKeywordsPredicate.normalizedKeywords);
+        return keywords.equals(otherNameContainsKeywordsPredicate.keywords);
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-                .add("keywords", normalizedKeywords)
+                .add("keywords", keywords)
                 .toString();
     }
 }

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -50,7 +50,7 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
         boolean hasSpecialCharacters = keywords.stream()
                 .anyMatch(k -> k.matches(".*[^a-zA-Z0-9\\s].*"));
 
-        // Substring matching for keywords with special characters (e.g., "O'Connor", "Smith-Jones")
+        // Use only substring matching for keywords with special characters
         if (hasSpecialCharacters) {
             String name = person.getName().fullName.toLowerCase();
 

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -64,12 +64,6 @@ public class FindCommandParserTest {
                 String.format(MESSAGE_UNEXPECTED_EXTRA_INPUT, "tc/cs2103"));
     }
 
-    @Test
-    public void parse_validMultipleNamesWithStandaloneSpecialCharacters_throwsParseException() {
-        assertParseFailure(parser, "n/bob . prim",
-                String.format(MESSAGE_INVALID_KEYWORD_WITH_ONLY_SPECIAL_CHARACTERS, "n/", "."));
-    }
-
     //============================== SUCCESS CASES - One Field ===================================
     @Test
     public void parse_validSingleNamePrefix_returnsFindCommand() {
@@ -91,17 +85,6 @@ public class FindCommandParserTest {
         assertParseSuccess(parser, "n/Alice Bob", expectedFindCommand);
         assertParseSuccess(parser, "n/Alice n/Bob", expectedFindCommand);
         assertParseSuccess(parser, "n/Alice \t \t \tBob", expectedFindCommand);
-    }
-
-    @Test
-    public void parse_validMultipleNamesNoStandaloneSpecialCharacters_returnsFindCommand() {
-        List<String> names = List.of("Bob", "C.", "Prim");
-
-        FindCommand expectedFindCommand =
-                new FindCommand(new NameEmailTagPredicate(names, List.of(), List.of()));
-
-        assertParseSuccess(parser, "n/Bob C. Prim", expectedFindCommand);
-        assertParseSuccess(parser, "n/Bob n/C. n/Prim", expectedFindCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_KEYWORD_WITH_ONLY_SPECIAL_CHARACTERS;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_PREFIX_WITH_NO_INPUT;
 import static seedu.address.logic.Messages.MESSAGE_PREAMBLE_NOT_EMPTY;
 import static seedu.address.logic.Messages.MESSAGE_UNEXPECTED_EXTRA_INPUT;

--- a/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
@@ -37,10 +37,6 @@ public class NameContainsKeywordsPredicateTest {
 
         // different predicate -> returns false
         assertFalse(firstPredicate.equals(secondPredicate));
-
-        // empty and whitespace keywords -> returns true
-        List<String> thirdPredicateKeywordList = Arrays.asList("first", " ", "second", "");
-        assertTrue(secondPredicate.equals(new NameContainsKeywordsPredicate(thirdPredicateKeywordList)));
     }
 
     //============================== SUCCESS CASES ===================================
@@ -66,10 +62,6 @@ public class NameContainsKeywordsPredicateTest {
         predicate = new NameContainsKeywordsPredicate(List.of("Alice", "B"));
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
-        // Substring match once keyword is normalized and split
-        predicate = new NameContainsKeywordsPredicate(Collections.singletonList("Alice-Bob"));
-        assertTrue(predicate.test(new PersonBuilder().withName("Alice Johnson").build()));
-
         // Mixed-case keywords
         predicate = new NameContainsKeywordsPredicate(Arrays.asList("aLIce", "bOB"));
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
@@ -78,6 +70,10 @@ public class NameContainsKeywordsPredicateTest {
         // 1 transposition away from Alice (within threshold of 1)
         predicate = new NameContainsKeywordsPredicate(List.of("Aliec"));
         assertTrue(predicate.test(new PersonBuilder().withName("Alice").build()));
+
+        // Keyword contains special characters and is a substring of name
+        predicate = new NameContainsKeywordsPredicate(Collections.singletonList("Alice-Johnson"));
+        assertTrue(predicate.test(new PersonBuilder().withName("Alice-Johnson").build()));
     }
 
     //============================== FAILURE CASES ===================================
@@ -104,16 +100,19 @@ public class NameContainsKeywordsPredicateTest {
         // Test fuzzy match failure (outside threshold)
         predicate = new NameContainsKeywordsPredicate(List.of("AliceXXXX")); // 4 edits away from "Alice"
         assertFalse(predicate.test(new PersonBuilder().withName("Alice").build()));
+
+        // Keyword contains special characters but name does not
+        predicate = new NameContainsKeywordsPredicate(Collections.singletonList("Alice-Johnson"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice Johnson").build()));
     }
 
     @Test
     public void toStringMethod() {
         List<String> keywords = List.of("Keyword1", "Keyword2");
-        List<String> normalizedKeywords = List.of("keyword1", "keyword2");
         NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(keywords);
 
         String expected = NameContainsKeywordsPredicate.class.getCanonicalName()
-                + "{keywords=" + normalizedKeywords + "}";
+                + "{keywords=" + keywords + "}";
         assertEquals(expected, predicate.toString());
     }
 }


### PR DESCRIPTION
Fixes #492

Summary:
- `find n/Alice-John` will match `Alice-Johnson` and `Alice-John` but not `Alice John` or `Alice Johnson`
- `find n/....` no longer throws an error.